### PR TITLE
feat: implement undo and redo functionality with keyboard shortcuts

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,7 @@ let isDark = false;
 
 const canvasHistory = [];
 let historyIndex = -1;
+const MAX_HISTORY = 20;
 
 const container = document.getElementById('canvas-container');
 
@@ -79,8 +80,8 @@ function mouseReleased() {
     }
     canvasHistory.push(currentDrawing);
     historyIndex = canvasHistory.length - 1;
-    if (canvasHistory.length > 20) {
-        canvasHistory.shift(); // Limit history size to 20
+    if (canvasHistory.length > MAX_HISTORY) {
+        canvasHistory.shift(); // Limit history size to MAX_HISTORY
         historyIndex--;
     }
 }

--- a/js/app.js
+++ b/js/app.js
@@ -71,19 +71,22 @@ function mousePressed() {
 }
 
 function mouseReleased() {
-    isDrawing = false;
 
-    // Save the current drawing state to history
-    const currentDrawing = drawingLayer.get();
-    if (historyIndex < canvasHistory.length - 1) {
-        canvasHistory.splice(historyIndex + 1);
+    if (isDrawing) {
+        // Save the current drawing state to history
+        const currentDrawing = drawingLayer.get();
+        if (historyIndex < canvasHistory.length - 1) {
+            canvasHistory.splice(historyIndex + 1);
+        }
+        canvasHistory.push(currentDrawing);
+        historyIndex = canvasHistory.length - 1;
+        if (canvasHistory.length > MAX_HISTORY) {
+            canvasHistory.shift(); // Limit history size to MAX_HISTORY
+            historyIndex--;
+        }
     }
-    canvasHistory.push(currentDrawing);
-    historyIndex = canvasHistory.length - 1;
-    if (canvasHistory.length > MAX_HISTORY) {
-        canvasHistory.shift(); // Limit history size to MAX_HISTORY
-        historyIndex--;
-    }
+
+    isDrawing = false;
 }
 
 function undo() {
@@ -104,18 +107,16 @@ function undo() {
         });
     }
 
-    clear();
-    image(gridLayer, 0, 0);
-    image(drawingLayer, 0, 0);
-
-    // Reset the current tool to pencil after undo
-    selectTool('pencil');
+    draw();
+    console.log(`Undo: ${historyIndex}/${canvasHistory.length - 1}`);
 }
 
 function redo() {
     if (historyIndex < canvasHistory.length - 1) {
         historyIndex++;
-        drawingLayer = canvasHistory[historyIndex].get();
+        let lastDrawing = canvasHistory[historyIndex];
+        drawingLayer.clear();
+        drawingLayer.image(lastDrawing, 0, 0);
     } else {
         Swal.fire({
             title: 'No more redos',
@@ -124,10 +125,8 @@ function redo() {
             customClass: getSwalThemeClasses()
         });
     }
-
-    clear();
-    image(gridLayer, 0, 0);
-    image(drawingLayer, 0, 0);
+    console.log(`Redo: ${historyIndex}/${canvasHistory.length - 1}`);
+    draw();
 }
 
 function windowResized() {

--- a/js/app.js
+++ b/js/app.js
@@ -67,7 +67,11 @@ function draw() {
 
 function mousePressed() {
     if (Swal.isVisible()) return;  // Prevent drawing if a modal is open
-    isDrawing = true;
+    
+    // Check if mouse is inside the canvas bounds
+    if (mouseX >= 0 && mouseX <= width && mouseY >= 0 && mouseY <= height) {
+        isDrawing = true;
+    }
 }
 
 function mouseReleased() {


### PR DESCRIPTION
This pull request introduces an undo/redo functionality to the drawing application by adding a history management system and corresponding keyboard shortcuts. The changes include tracking drawing states, limiting the history size, and implementing undo/redo logic with user feedback.

### Undo/Redo Functionality:

* **History Management**: Added `canvasHistory` array, `historyIndex`, and `MAX_HISTORY` constant to track and limit the history of drawing states (`js/app.js`, [js/app.jsR11-R14](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR11-R14)).
* **Undo Logic**: Implemented the `undo()` function to revert to a previous drawing state, with user feedback when no more undos are available (`js/app.js`, [js/app.jsR70-R135](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR70-R135)).
* **Redo Logic**: Implemented the `redo()` function to restore a later drawing state, with user feedback when no more redos are available (`js/app.js`, [js/app.jsR70-R135](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR70-R135)).

### User Interaction Enhancements:

* **Mouse Boundary Check**: Updated `mousePressed()` to ensure drawing only occurs within canvas bounds (`js/app.js`, [js/app.jsR70-R135](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR70-R135)).
* **Keyboard Shortcuts**: Added event listeners for `Ctrl+Z`/`Cmd+Z` (undo) and `Ctrl+Y`/`Cmd+Shift+Z` (redo) to improve usability (`js/app.js`, [js/app.jsR373-R386](diffhunk://#diff-32cdce28ac549728f6a28999f6d874aa4f29e6da1406c28c3134cd8d421a866aR373-R386)).